### PR TITLE
Support for running code as a service

### DIFF
--- a/handler-new-pulsefile-catalogqt.py
+++ b/handler-new-pulsefile-catalogqt.py
@@ -74,6 +74,7 @@ if __name__ == '__main__':
         command = ['java',
                    '-jar',
                    args.jar,
+                   '--run-as-service',
                    '-addRequest',
                    '--user',
                    'imas-inotify-auto-updater',


### PR DESCRIPTION
token will be read from `~/.catalogqt/service/access_token`.

In order to get valid token, it is required to call:

```
java -jar /home/imas/opt/catalog_qt_2/client/catalog-ws-client/target/catalogAPI.jar -keyCloakServiceLogin
```

before calling any other command that passes token to WebServices. In the future, this step will be done automatically.