### PR TITLE
Small changes that make it possible to run catalogAPI.jar in debug mode

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -6,4 +6,5 @@ action = ./handler-new-pulsefile-catalogqt.py
 action_relative = True
 
 jar = /catalog_qt_2/client/catalog-ws-client/target/catalogAPI.jar
+; debug = '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:32887'
 url = http://server:8080

--- a/handler-new-pulsefile-catalogqt.py
+++ b/handler-new-pulsefile-catalogqt.py
@@ -40,6 +40,8 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Watch for creation of pulsefiles')
     parser.add_argument('--jar', help='path to catalog-ws-client JAR',
                         default='/catalog_qt_2/client/catalog-ws-client/target/catalogAPI.jar')
+    parser.add_argument('--debug', help='debugger settings for catalogAPI.jar',
+                        default='')
     parser.add_argument('--url', help='URL of webservice endpoint', default='http://server:8080')
     parser.add_argument('file')
     args = parser.parse_args()
@@ -71,16 +73,31 @@ if __name__ == '__main__':
             occurrence = ''
             logging.info('Did not find occurrence setting, using default value')
 
-        command = ['java',
-                   '-jar',
-                   args.jar,
-                   '--run-as-service',
-                   '-addRequest',
-                   '--user',
-                   'imas-inotify-auto-updater',
-                   '--url',
-                   args.url,
-                   '--experiment-uri',
-                   f'mdsplus:/?user={user};machine={tokamak};version={version};shot={shot};run={run}{occurrence}']
+        if args.debug is None:
+            command = ['java',
+                       '-jar',
+                       args.jar,
+                       '--run-as-service',
+                       '-addRequest',
+                       '--user',
+                       'imas-inotify-auto-updater',
+                       '--url',
+                       args.url,
+                       '--experiment-uri',
+                       f'mdsplus:/?user={user};machine={tokamak};version={version};shot={shot};run={run}{occurrence}']
+        else:
+            command = ['java',
+                       args.debug.replace("'",""),
+                       '-jar',
+                       args.jar,
+                       '--run-as-service',
+                       '-addRequest',
+                       '--user',
+                       'imas-inotify-auto-updater',
+                       '--url',
+                       args.url,
+                       '--experiment-uri',
+                       f'mdsplus:/?user={user};machine={tokamak};version={version};shot={shot};run={run}{occurrence}']
+
         logging.info(f'Executing command: {" ".join(command)}')
         subprocess.run(command)


### PR DESCRIPTION
This small change allows to run catalogAPI.jar in debug mode. This is useful in case we want to debug the whole process of populating data. With this change it's possible to attach to Docker image.