### PR TITLE
Support for JDWP based debugging

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -6,4 +6,5 @@ action = ./handler-new-pulsefile-catalogqt.py
 action_relative = True
 
 jar = /catalog_qt_2/client/catalog-ws-client/target/catalogAPI.jar
+; debug = '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:32887'
 url = http://server:8080

--- a/handler-new-pulsefile-catalogqt.py
+++ b/handler-new-pulsefile-catalogqt.py
@@ -11,7 +11,6 @@ from typing import Tuple
 def parse_path(core: str) -> Tuple[str, str, str, int, int]:
     '''
     Parse path and filename to retrieve user, machine, version, shot and run.
-
     :param core: The path to file without extension i.e. /home/imas/public/imasdb/test/3/0/ids_10001
     :return: A 5-tuple with user, machine, version, shot and run.
     '''
@@ -37,9 +36,13 @@ def parse_path(core: str) -> Tuple[str, str, str, int, int]:
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
 
+    debug_imas_inotify = os.getenv("DEBUG_IMAS_INOTIFY")
+
     parser = argparse.ArgumentParser(description='Watch for creation of pulsefiles')
     parser.add_argument('--jar', help='path to catalog-ws-client JAR',
                         default='/catalog_qt_2/client/catalog-ws-client/target/catalogAPI.jar')
+    parser.add_argument('--debug', help='debugger settings for catalogAPI.jar',
+                        default=None)
     parser.add_argument('--url', help='URL of webservice endpoint', default='http://server:8080')
     parser.add_argument('file')
     args = parser.parse_args()
@@ -71,16 +74,37 @@ if __name__ == '__main__':
             occurrence = ''
             logging.info('Did not find occurrence setting, using default value')
 
-        command = ['java',
-                   '-jar',
-                   args.jar,
-                   '--run-as-service',
-                   '-addRequest',
-                   '--user',
-                   'imas-inotify-auto-updater',
-                   '--url',
-                   args.url,
-                   '--experiment-uri',
-                   f'mdsplus:/?user={user};machine={tokamak};version={version};shot={shot};run={run}{occurrence}']
+        if debug_imas_inotify is None and args.debug is None:
+            command = ['java',
+                       '-jar',
+                       args.jar,
+                       '--run-as-service',
+                       '-addRequest',
+                       '--user',
+                       'imas-inotify-auto-updater',
+                       '--url',
+                       args.url,
+                       '--experiment-uri',
+                       f'mdsplus:/?user={user};machine={tokamak};version={version};shot={shot};run={run}{occurrence}']
+        else:
+            if args.debug is None:
+                debug_string_jwdp='-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:32887'
+            else:
+                debug_string_jwdp=args.debug.replace("'","")
+ 
+            command = ['java',
+                       debug_string_jwdp,
+                       '-jar',
+                       args.jar,
+                       '--run-as-service',
+                       '-addRequest',
+                       '--user',
+                       'imas-inotify-auto-updater',
+                       '--url',
+                       args.url,
+                       '--experiment-uri',
+                       f'mdsplus:/?user={user};machine={tokamak};version={version};shot={shot};run={run}{occurrence}']
+
         logging.info(f'Executing command: {" ".join(command)}')
         subprocess.run(command)
+


### PR DESCRIPTION
Support for `JDWP` based debugger. We have two options here:

- we can define `debug` element inside `config.ini`
- we can use env variable `DEBUG_IMAS_INOTIFY`

Both will enable running `Java` process in debug mode